### PR TITLE
Add update interval parameter for social feeds.

### DIFF
--- a/src/main/scala/ch/becompany/social/github/GithubFeed.scala
+++ b/src/main/scala/ch/becompany/social/github/GithubFeed.scala
@@ -16,10 +16,12 @@ import scala.util.{Failure, Try}
   * @param org The name of the organization.
   * @param ec The execution context.
   */
-class GithubFeed(org: String)(implicit ec: ExecutionContext) extends SocialFeed {
+class GithubFeed(org: String, userUpdateInterval: FiniteDuration = 1 minute)(implicit ec: ExecutionContext) extends SocialFeed {
 
   private val system = ActorSystem()
-  private val updateInterval = 5 minutes
+  // GitHub unauthenticated requests are limited to 60 per hour. => 1 req/m
+  private val updateIntervalMin: FiniteDuration = 1 minute
+  private val updateInterval = updateIntervalMin.max(userUpdateInterval)
 
   /**
     * Returns the latest `num` GitHub events.

--- a/src/main/scala/ch/becompany/social/twitter/TwitterFeed.scala
+++ b/src/main/scala/ch/becompany/social/twitter/TwitterFeed.scala
@@ -5,6 +5,7 @@ import java.time.Instant
 import akka.stream.scaladsl.Source
 import ch.becompany.social.{SocialFeed, Status}
 
+import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
@@ -16,11 +17,11 @@ import scala.util.Try
   *   [[https://dev.twitter.com/overview/api/users Twitter Developer Documentation]].
   * @param ec The execution context.
   */
-class TwitterFeed(screenName: String)(implicit ec: ExecutionContext)
+class TwitterFeed(screenName: String, userUpdateInterval: FiniteDuration = 1 minute)(implicit ec: ExecutionContext)
   extends SocialFeed {
 
   private lazy val client = new TwitterClient(screenName)
-  private lazy val streamFuture = client.userId.map(id => TwitterStream("follow" -> id))
+  private lazy val streamFuture = client.userId.map(id => TwitterStream(userUpdateInterval, "follow" -> id))
 
   /**
     * Returns the latest `num` Twitter tweets.


### PR DESCRIPTION
Set a minimum value to prevent rate limits and allow to include a custom FiniteDuration as optional parameter.