### PR TITLE
Upgrade Akka to latest version. Use custom akka-actor due to the IPv6 bug.

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -3,7 +3,8 @@ import sbt._
 object Settings {
 
   object Versions {
-    val akka = "2.4.16"
+    val akka = "2.4.17"
+    val akkaActor = "2.4.17-BECOMPANY"
     val scalaTest = "3.0.0"
     val akkaHttp = "10.0.0"
     val kOAuth = "1.1.0"
@@ -15,6 +16,7 @@ object Settings {
   }
 
   object Dependencies {
+    val akkaActor = "com.typesafe.akka" %% "akka-actor" % Versions.akkaActor
     val akkaStream = "com.typesafe.akka" %% "akka-stream" % Versions.akka
     val akkaStreamTestkit = "com.typesafe.akka" %% "akka-stream-testkit" % Versions.akka
     val akkaHttp = "com.typesafe.akka" %% "akka-http-core" % Versions.akkaHttp
@@ -31,6 +33,7 @@ object Settings {
   val dependencies: Seq[ModuleID] = {
     import Dependencies._
     Seq(
+      akkaActor,
       akkaStream,
       akkaStreamTestkit,
       akkaHttp,


### PR DESCRIPTION
Use patched version of Akka while the IPv6 fix is released in the version 2.4.18.