### PR TITLE
Move same code to generic implementation.

### DIFF
--- a/src/main/scala/ch/becompany/social/SocialFeed.scala
+++ b/src/main/scala/ch/becompany/social/SocialFeed.scala
@@ -2,10 +2,14 @@ package ch.becompany.social
 
 import java.time.Instant
 
+import akka.actor.ActorSystem
 import akka.stream.scaladsl.Source
+import akka.pattern.after
 
 import scala.concurrent.Future
-import scala.util.Try
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Try}
 
 /**
   * Feed providing a stream of status messages from a social networking platform.
@@ -24,4 +28,44 @@ trait SocialFeed {
     * @return The source providing the stream.
     */
   def stream(): Source[(Instant, Try[Status]), _]
+}
+
+/**
+* Feed providing a stream of status messages from a social networking platform based on a polling implementation.
+*/
+trait PollingSocialFeed extends SocialFeed {
+
+  private val numberOfEventsToFetch = 20
+
+  val system = ActorSystem()
+  val updateInterval: FiniteDuration
+
+  /**
+    * Create a stream that request 20 new events based on "updateInterval". The events are sorted by date.
+    * @return The source providing the stream.
+    */
+  override def stream(): Source[(Instant, Try[Status]), _] =
+    Source.
+      unfoldAsync[Instant, List[(Instant, Try[Status])]](Instant.now) { lastUpdate =>
+      after(updateInterval, using = system.scheduler) {
+        events(lastUpdate) map { statuses =>
+          Some((getLastUpdate(statuses) getOrElse lastUpdate, statuses))
+        }
+      }
+    }.
+      flatMapConcat(list => Source.fromIterator(() => list.iterator))
+
+  private def getLastUpdate(statuses: List[(Instant, Try[Status])]): Option[Instant] =
+    statuses.
+      lastOption.
+      map(_._1)
+
+  private def events(lastUpdate: Instant): Future[List[(Instant, Try[Status])]] =
+    latest(numberOfEventsToFetch).
+      map(_.
+        filter(_._1.isAfter(lastUpdate)).
+        sortBy(_._1).
+        map { case (date, status) => (date, Try(status)) }
+      ).
+      recover { case e => List(Instant.now -> Failure(e)) }
 }

--- a/src/main/scala/ch/becompany/social/facebook/FacebookFeed.scala
+++ b/src/main/scala/ch/becompany/social/facebook/FacebookFeed.scala
@@ -2,22 +2,20 @@ package ch.becompany.social.facebook
 
 import java.time.Instant
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.Source
-import akka.pattern.after
-import ch.becompany.social.{SocialFeed, Status}
+import ch.becompany.social.{PollingSocialFeed, Status}
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.FiniteDuration
-import scala.util.{Failure, Try}
 
-class FacebookFeed(pageId: String, userUpdateInterval: FiniteDuration = 1 minute)(implicit ec: ExecutionContext) extends SocialFeed {
+class FacebookFeed(pageId: String, userUpdateInterval: FiniteDuration = 1 minute)(implicit ec: ExecutionContext)
+  extends PollingSocialFeed
+{
 
-  private val system = ActorSystem()
   // GitHub unauthenticated requests are limited to 60 per hour. => 1 req/m
   private val updateIntervalMin: FiniteDuration = 1 minute
-  private val updateInterval = updateIntervalMin.max(userUpdateInterval)
+  override val updateInterval = updateIntervalMin.max(userUpdateInterval)
+
   /**
     * Returns the latest `num` social media status messages.
     *
@@ -26,33 +24,4 @@ class FacebookFeed(pageId: String, userUpdateInterval: FiniteDuration = 1 minute
     */
   override def latest(num: Int): Future[List[(Instant, Status)]] = FacebookClient.posts(pageId)
 
-  private def events(lastUpdate: Instant): Future[List[(Instant, Try[Status])]] =
-    FacebookClient.posts(pageId).
-      map(_.
-        filter(_._1.isAfter(lastUpdate)).
-        sortBy(_._1).
-        map { case (date, status) => (date, Try(status)) }
-      ).
-      recover { case e => List(Instant.now -> Failure(e)) }
-
-  private def getLastUpdate(statuses: List[(Instant, Try[Status])]): Option[Instant] =
-    statuses.
-      lastOption.
-      map(_._1)
-
-  /**
-    * Streams future social media status messages.
-    *
-    * @return The source providing the stream.
-    */
-  override def stream(): Source[(Instant, Try[Status]), _] =
-    Source.
-      unfoldAsync[Instant, List[(Instant, Try[Status])]](Instant.now) { lastUpdate =>
-      after(updateInterval, using = system.scheduler) {
-        events(lastUpdate) map { statuses =>
-          Some((getLastUpdate(statuses) getOrElse lastUpdate, statuses))
-        }
-      }
-    }.
-    flatMapConcat(list => Source.fromIterator(() => list.iterator))
 }

--- a/src/main/scala/ch/becompany/social/facebook/FacebookFeed.scala
+++ b/src/main/scala/ch/becompany/social/facebook/FacebookFeed.scala
@@ -12,7 +12,6 @@ class FacebookFeed(pageId: String, userUpdateInterval: FiniteDuration = 1 minute
   extends PollingSocialFeed
 {
 
-  // GitHub unauthenticated requests are limited to 60 per hour. => 1 req/m
   private val updateIntervalMin: FiniteDuration = 1 minute
   override val updateInterval = updateIntervalMin.max(userUpdateInterval)
 

--- a/src/main/scala/ch/becompany/social/github/GithubFeed.scala
+++ b/src/main/scala/ch/becompany/social/github/GithubFeed.scala
@@ -2,26 +2,23 @@ package ch.becompany.social.github
 
 import java.time.Instant
 
-import akka.actor.ActorSystem
-import akka.pattern.after
-import akka.stream.scaladsl.Source
-import ch.becompany.social.{SocialFeed, Status}
+import ch.becompany.social.{PollingSocialFeed, Status}
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Try}
 
 /**
   * Streams GitHub events for an organization.
   * @param org The name of the organization.
   * @param ec The execution context.
   */
-class GithubFeed(org: String, userUpdateInterval: FiniteDuration = 1 minute)(implicit ec: ExecutionContext) extends SocialFeed {
+class GithubFeed(org: String, userUpdateInterval: FiniteDuration = 1 minute)(implicit ec: ExecutionContext)
+  extends PollingSocialFeed
+{
 
-  private val system = ActorSystem()
   // GitHub unauthenticated requests are limited to 60 per hour. => 1 req/m
   private val updateIntervalMin: FiniteDuration = 1 minute
-  private val updateInterval = updateIntervalMin.max(userUpdateInterval)
+  override val updateInterval = updateIntervalMin.max(userUpdateInterval)
 
   /**
     * Returns the latest `num` GitHub events.
@@ -30,36 +27,4 @@ class GithubFeed(org: String, userUpdateInterval: FiniteDuration = 1 minute)(imp
     */
   override def latest(num: Int): Future[List[(Instant, Status)]] =
     GithubClient.events(org).map(_.sortBy(_._1).takeRight(num))
-
-  private def events(lastUpdate: Instant): Future[List[(Instant, Try[Status])]] =
-    GithubClient.events(org).
-      map(_.
-        filter(_._1.isAfter(lastUpdate)).
-        sortBy(_._1).
-        map { case (date, status) => (date, Try(status)) }
-      ).
-      recover { case e => List(Instant.now -> Failure(e)) }
-
-  private def getLastUpdate(statuses: List[(Instant, Try[Status])]): Option[Instant] =
-    statuses.
-      lastOption.
-      map(_._1)
-
-  /**
-    * Streams GitHub events. The stream is populated using periodic requests;
-    * the interval between requests is set in the `updateInterval` value. The first
-    * request is emitted after `updateInterval`.
-    * @return The source providing the stream.
-    */
-  override def stream(): Source[(Instant, Try[Status]), _] =
-    Source.
-      unfoldAsync[Instant, List[(Instant, Try[Status])]](Instant.now) { lastUpdate =>
-        after(updateInterval, using = system.scheduler) {
-          events(lastUpdate) map { statuses =>
-            Some((getLastUpdate(statuses) getOrElse lastUpdate, statuses))
-          }
-        }
-      }.
-      flatMapConcat(list => Source.fromIterator(() => list.iterator))
-
 }

--- a/src/main/scala/ch/becompany/social/twitter/TwitterFeed.scala
+++ b/src/main/scala/ch/becompany/social/twitter/TwitterFeed.scala
@@ -2,31 +2,24 @@ package ch.becompany.social.twitter
 
 import java.time.Instant
 
-import akka.actor.ActorSystem
-import akka.pattern.after
-import akka.stream.scaladsl.Source
-import ch.becompany.social.{SocialFeed, Status}
+import ch.becompany.social.{PollingSocialFeed, Status}
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Try}
 
 /**
-  * Streams Twitter tweets. The continuous stream is generated based on the
-  * [[https://dev.twitter.com/streaming/reference/post/statuses/filter statuses/filter]] method
-  * of the Twitter streaming API.
+  * Streams Twitter tweets. The continuous stream is generated based on polling with ETAG support.
   * @param screenName The screen name of the user, see
   *   [[https://dev.twitter.com/overview/api/users Twitter Developer Documentation]].
   * @param ec The execution context.
   */
 class TwitterFeed(screenName: String, userUpdateInterval: FiniteDuration = 1 minute)(implicit ec: ExecutionContext)
-  extends SocialFeed {
+  extends PollingSocialFeed {
 
-  private val system = ActorSystem()
   private lazy val client = new TwitterClient(screenName)
   // Twitter unauthenticated requests are limited to 15 per hour. => 1 req/m
   private val updateIntervalMin: FiniteDuration = 1 minute
-  private val updateInterval = updateIntervalMin.max(userUpdateInterval)
+  override val updateInterval = updateIntervalMin.max(userUpdateInterval)
 
   /**
     * Returns the latest `num` Twitter tweets.
@@ -35,35 +28,5 @@ class TwitterFeed(screenName: String, userUpdateInterval: FiniteDuration = 1 min
     */
   override def latest(num: Int): Future[List[(Instant, Status)]] =
     client.latest(num)
-
-
-  private def events(lastUpdate: Instant): Future[List[(Instant, Try[Status])]] =
-    client.latest(5).
-      map(_.
-        filter(_._1.isAfter(lastUpdate)).
-        sortBy(_._1).
-        map { case (date, status) => (date, Try(status)) }
-      ).
-      recover { case e => List(Instant.now -> Failure(e)) }
-
-  private def getLastUpdate(statuses: List[(Instant, Try[Status])]): Option[Instant] =
-    statuses.
-      lastOption.
-      map(_._1)
-
-  /**
-    * Streams Twitter tweets.
-    * @return The source providing the stream.
-    */
-  override def stream(): Source[(Instant, Try[Status]), _] =
-  Source.
-    unfoldAsync[Instant, List[(Instant, Try[Status])]](Instant.now) { lastUpdate =>
-    after(updateInterval, using = system.scheduler) {
-      events(lastUpdate) map { statuses =>
-        Some((getLastUpdate(statuses) getOrElse lastUpdate, statuses))
-      }
-    }
-  }.
-    flatMapConcat(list => Source.fromIterator(() => list.iterator))
 
 }


### PR DESCRIPTION
Previously we had the code for polling repeated in three places. Create a generic polling implementation for easy implementation.